### PR TITLE
docs: restructure boilerplate zone inputs to nested zone block

### DIFF
--- a/.boilerplate/inputs.yaml
+++ b/.boilerplate/inputs.yaml
@@ -6,13 +6,14 @@
 github:
   org: ""
 
-# zone_name: "prod" # (Required) Zone/environment identifier used in the repo name.
-#   Examples: dev, stage, prod, shared, sandbox
-zone_name: ""
-
-# product_name: "acme" # (Required) Short product or platform identifier used in the repo name.
-#   The created repository will be named: <product_name>-iac-zone-<zone_name>
-product_name: ""
+# zone: # (Required) Zone and product configuration
+#   name: "prod"    # (Required) Zone/environment identifier used in the repo name.
+#                   #   Examples: dev, stage, prod, shared, sandbox
+#   product: "acme" # (Required) Short product or platform identifier used in the repo name.
+#                   #   The created repository will be named: <product>-iac-zone-<name>
+zone:
+  name: ""
+  product: ""
 
 # description: "" # (Optional) Human-readable description for the GitHub repository. Default: ""
 description: ""

--- a/.boilerplate/terragrunt.hcl
+++ b/.boilerplate/terragrunt.hcl
@@ -45,12 +45,18 @@ inputs = {
   spoke_def  = local.spoke_vars.spoke
   {{- range .requiredVariables }}
   {{- if ne .Name "org" }}
-  {{ .Name }} = local.local_vars.{{ .Name }}
+  {{- if eq .Name "zone_name" }}
+  zone_name = try(local.local_vars.zone.name, local.local_vars.zone_name)
+  {{- else if eq .Name "product_name" }}
+  product_name = try(local.local_vars.zone.product, local.local_vars.product_name)
+  {{- else }}
+  {{ .Name }} = try(local.local_vars.{{ .Name }}, "")
+  {{- end }}
   {{- end }}
   {{- end }}
   {{- range .optionalVariables }}
   {{- if not (eq .Name "extra_tags" "is_hub" "spoke_def" "org") }}
-  {{ .Name }} = try(local.local_vars.{{ replace .Name '_' '.' }}, {{ .DefaultValue }})
+  {{ .Name }} = try(local.local_vars.{{ .Name }}, {{ .DefaultValue }})
   {{- end }}
   {{- end }}
   extra_tags = local.tags

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | 6.12.0 |
+| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -101,13 +101,14 @@ terragrunt apply
 github:
   org: "my-github-org"
 
-# zone_name: "prod" # (Required) Zone/environment identifier used in the repo name.
-#   Examples: dev, stage, prod, shared, sandbox
-zone_name: "prod"
-
-# product_name: "acme" # (Required) Short product or platform identifier used in the repo name.
-#   The created repository will be named: <product_name>-iac-zone-<zone_name>
-product_name: "acme"
+# zone: # (Required) Zone and product configuration
+#   name: "prod"    # (Required) Zone/environment identifier used in the repo name.
+#                   #   Examples: dev, stage, prod, shared, sandbox
+#   product: "acme" # (Required) Short product or platform identifier used in the repo name.
+#                   #   The created repository will be named: <product>-iac-zone-<name>
+zone:
+  name: "prod"
+  product: "acme"
 
 # description: "" # (Optional) Human-readable description for the GitHub repository. Default: ""
 description: "Acme Production IaC Zone"
@@ -161,8 +162,8 @@ inputs = {
   is_hub       = false
   org          = local.env_vars.org
   spoke_def    = local.spoke_vars.spoke
-  zone_name    = local.local_vars.zone_name
-  product_name = local.local_vars.product_name
+  zone_name    = try(local.local_vars.zone.name, local.local_vars.zone_name)
+  product_name = try(local.local_vars.zone.product, local.local_vars.product_name)
   description  = try(local.local_vars.description, "")
   extra_tags   = local.tags
 }
@@ -173,8 +174,8 @@ inputs = {
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `github.org` | `string` | yes | — | GitHub organization name or user owning the repositories (sets provider `owner`) |
-| `zone_name` | `string` | yes | — | Zone/environment identifier (e.g. dev, stage, prod) |
-| `product_name` | `string` | yes | — | Short product identifier used in the repo name |
+| `zone.name` | `string` | yes | — | Zone/environment identifier (e.g. dev, stage, prod) |
+| `zone.product` | `string` | yes | — | Short product identifier used in the repo name |
 | `description` | `string` | no | `""` | GitHub repository description |
 | `org` | `object` | yes | — | Organization details (injected by Terragrunt hierarchy) |
 | `is_hub` | `bool` | no | `false` | Hub/spoke configuration flag |
@@ -205,7 +206,7 @@ inputs = {
    ```sh
    terragrunt scaffold github.com/cloudopsworks/terraform-module-github-zone-management
    ```
-4. Edit `inputs.yaml` — set `github.org`, `zone_name`, `product_name`, and optionally `description`.
+4. Edit `inputs.yaml` — set `github.org`, `zone.name`, `zone.product`, and optionally `description`.
 5. Initialize and apply:
    ```sh
    terragrunt init
@@ -251,7 +252,7 @@ terragrunt apply
 ```
 
 After apply, the output `full_name` will be `your-org/acme-iac-zone-prod` (or whatever
-`product_name` and `zone_name` you set).
+`zone.product` and `zone.name` you set).
 
 
 
@@ -278,7 +279,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.0 |
+| <a name="provider_github"></a> [github](#provider\_github) | 6.12.0 |
 
 ## Modules
 

--- a/README.yaml
+++ b/README.yaml
@@ -79,13 +79,14 @@ usage: |-
   github:
     org: "my-github-org"
 
-  # zone_name: "prod" # (Required) Zone/environment identifier used in the repo name.
-  #   Examples: dev, stage, prod, shared, sandbox
-  zone_name: "prod"
-
-  # product_name: "acme" # (Required) Short product or platform identifier used in the repo name.
-  #   The created repository will be named: <product_name>-iac-zone-<zone_name>
-  product_name: "acme"
+  # zone: # (Required) Zone and product configuration
+  #   name: "prod"    # (Required) Zone/environment identifier used in the repo name.
+  #                   #   Examples: dev, stage, prod, shared, sandbox
+  #   product: "acme" # (Required) Short product or platform identifier used in the repo name.
+  #                   #   The created repository will be named: <product>-iac-zone-<name>
+  zone:
+    name: "prod"
+    product: "acme"
 
   # description: "" # (Optional) Human-readable description for the GitHub repository. Default: ""
   description: "Acme Production IaC Zone"
@@ -139,8 +140,8 @@ usage: |-
     is_hub       = false
     org          = local.env_vars.org
     spoke_def    = local.spoke_vars.spoke
-    zone_name    = local.local_vars.zone_name
-    product_name = local.local_vars.product_name
+    zone_name    = try(local.local_vars.zone.name, local.local_vars.zone_name)
+    product_name = try(local.local_vars.zone.product, local.local_vars.product_name)
     description  = try(local.local_vars.description, "")
     extra_tags   = local.tags
   }
@@ -151,8 +152,8 @@ usage: |-
   | Name | Type | Required | Default | Description |
   |------|------|----------|---------|-------------|
   | `github.org` | `string` | yes | — | GitHub organization name or user owning the repositories (sets provider `owner`) |
-  | `zone_name` | `string` | yes | — | Zone/environment identifier (e.g. dev, stage, prod) |
-  | `product_name` | `string` | yes | — | Short product identifier used in the repo name |
+  | `zone.name` | `string` | yes | — | Zone/environment identifier (e.g. dev, stage, prod) |
+  | `zone.product` | `string` | yes | — | Short product identifier used in the repo name |
   | `description` | `string` | no | `""` | GitHub repository description |
   | `org` | `object` | yes | — | Organization details (injected by Terragrunt hierarchy) |
   | `is_hub` | `bool` | no | `false` | Hub/spoke configuration flag |
@@ -205,7 +206,7 @@ examples: |-
   ```
 
   After apply, the output `full_name` will be `your-org/acme-iac-zone-prod` (or whatever
-  `product_name` and `zone_name` you set).
+  `zone.product` and `zone.name` you set).
 
 # How to get started quickly
 quickstart: |-
@@ -222,7 +223,7 @@ quickstart: |-
      ```sh
      terragrunt scaffold github.com/cloudopsworks/terraform-module-github-zone-management
      ```
-  4. Edit `inputs.yaml` — set `github.org`, `zone_name`, `product_name`, and optionally `description`.
+  4. Edit `inputs.yaml` — set `github.org`, `zone.name`, `zone.product`, and optionally `description`.
   5. Initialize and apply:
      ```sh
      terragrunt init

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | 6.12.0 |
+| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.0 |
+| <a name="provider_github"></a> [github](#provider\_github) | 6.12.0 |
 
 ## Modules
 


### PR DESCRIPTION
## Summary

- Restructure `.boilerplate/inputs.yaml`: replace flat `zone_name`/`product_name` keys with nested `zone:` block (`zone.name`, `zone.product`)
- Update `terragrunt.hcl` required-variable mappings to use `try(local.local_vars.zone.name, local.local_vars.zone_name)` for backward compatibility
- Revert optional-variable `replace` helper (flat lookup is correct for `description`)
- Update `README.yaml` and `README.md` usage examples and inputs reference table to reflect nested zone structure
- Regenerate `docs/terraform.md` and `README.md` via `make readme`

+semver: patch